### PR TITLE
Add XML prefix and default package icon

### DIFF
--- a/src/Bonsai.ZeroMQ/Properties/AssemblyInfo.cs
+++ b/src/Bonsai.ZeroMQ/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Bonsai.ZeroMQ", "zmq")]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Net")]


### PR DESCRIPTION
This PR sets the prefix for all ZeroMQ operators to `zmq` and sets the default icon for network communication packages.