### PR TITLE
Add operators for message manipulation

### DIFF
--- a/src/Bonsai.ZeroMQ/ConvertToString.cs
+++ b/src/Bonsai.ZeroMQ/ConvertToString.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using NetMQ;
+
+namespace Bonsai.ZeroMQ
+{
+    /// <summary>
+    /// Represents an operator that converts a sequence of message frames into a
+    /// sequence of strings using the default encoding.
+    /// </summary>
+    [Description("Converts a sequence of message frames into a sequence of strings using the default encoding.")]
+    public class ConvertToString : Transform<NetMQFrame, string>
+    {
+        /// <summary>
+        /// Converts an observable sequence of message frames into a sequence of
+        /// strings using the default encoding.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="NetMQFrame"/> objects representing individual
+        /// message frames.
+        /// </param>
+        /// <returns>
+        /// A sequence of strings extracted from each frame data buffer using the
+        /// default encoding.
+        /// </returns>
+        public override IObservable<string> Process(IObservable<NetMQFrame> source)
+        {
+            return source.Select(frame => frame.ConvertToString());
+        }
+    }
+}

--- a/src/Bonsai.ZeroMQ/ToMessage.cs
+++ b/src/Bonsai.ZeroMQ/ToMessage.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using NetMQ;
+
+namespace Bonsai.ZeroMQ
+{
+    /// <summary>
+    /// Represents an operator that creates a multiple part message from an observable sequence.
+    /// </summary>
+    [Description("Creates a multiple part message from an observable sequence.")]
+    public class ToMessage : Combinator<NetMQFrame, NetMQMessage>
+    {
+        /// <summary>
+        /// Creates a multiple part message from an observable sequence of individual
+        /// message frames.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="NetMQFrame"/> objects representing the individual
+        /// message parts.
+        /// </param>
+        /// <returns>
+        /// An observable sequence containing a single <see cref="NetMQMessage"/> object
+        /// representing the created multiple part message.
+        /// </returns>
+        public override IObservable<NetMQMessage> Process(IObservable<NetMQFrame> source)
+        {
+            return source.ToList().Select(frames =>
+            {
+                var message = new NetMQMessage(frames.Count);
+                foreach (var frame in frames)
+                {
+                    message.Append(frame);
+                }
+                return message;
+            });
+        }
+
+        /// <summary>
+        /// Creates a multiple part message from an observable sequence of individual
+        /// data buffers.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of byte-array objects representing the individual message parts.
+        /// </param>
+        /// <returns>
+        /// An observable sequence containing a single <see cref="NetMQMessage"/> object
+        /// representing the created multiple part message.
+        /// </returns>
+        public IObservable<NetMQMessage> Process(IObservable<byte[]> source)
+        {
+            return source.ToList().Select(buffers =>
+            {
+                var message = new NetMQMessage(buffers.Count);
+                foreach (var buffer in buffers)
+                {
+                    message.Append(buffer);
+                }
+                return message;
+            });
+        }
+
+        /// <summary>
+        /// Creates a multiple part message from an observable sequence of individual
+        /// message parts.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="string"/> objects representing the individual
+        /// message parts.
+        /// </param>
+        /// <returns>
+        /// An observable sequence containing a single <see cref="NetMQMessage"/> object
+        /// representing the created multiple part message.
+        /// </returns>
+        public IObservable<NetMQMessage> Process(IObservable<string> source)
+        {
+            return source.ToList().Select(parts =>
+            {
+                var message = new NetMQMessage(parts.Count);
+                foreach (var part in parts)
+                {
+                    message.Append(part, SendReceiveConstants.DefaultEncoding);
+                }
+                return message;
+            });
+        }
+    }
+}


### PR DESCRIPTION
This PR adds operators for formatting ZeroMQ multiple part messages and decoding a single message frame buffer as a string. These will simplify interfacing with simple text based protocols, and encoding both binary and text-based responses.