### PR TITLE
Use NetMQ poller for all receive sockets

### DIFF
--- a/src/Bonsai.ZeroMQ/Pull.cs
+++ b/src/Bonsai.ZeroMQ/Pull.cs
@@ -39,8 +39,12 @@ namespace Bonsai.ZeroMQ
                 var poller = new NetMQPoller { pull };
                 pull.ReceiveReady += (sender, e) =>
                 {
-                    var message = e.Socket.ReceiveMultipartMessage();
-                    observer.OnNext(message);
+                    NetMQMessage message = default;
+                    while (e.Socket.TryReceiveMultipartMessage(ref message))
+                    {
+                        observer.OnNext(message);
+                        message = default;
+                    }
                 };
                 poller.RunAsync();
                 return Disposable.Create(() => Task.Run(() =>

--- a/src/Bonsai.ZeroMQ/Response.cs
+++ b/src/Bonsai.ZeroMQ/Response.cs
@@ -55,14 +55,11 @@ namespace Bonsai.ZeroMQ
                     else responseContext.Response.OnCompleted(SendResponse);
                 };
                 poller.RunAsync();
-                return new CompositeDisposable
+                return Disposable.Create(() => Task.Run(() =>
                 {
-                    Disposable.Create(() => Task.Run(() =>
-                    {
-                        poller.Dispose();
-                        responseSocket.Dispose();
-                    }))
-                };
+                    poller.Dispose();
+                    responseSocket.Dispose();
+                }));
             });
         }
 

--- a/src/Bonsai.ZeroMQ/Router.cs
+++ b/src/Bonsai.ZeroMQ/Router.cs
@@ -52,14 +52,11 @@ namespace Bonsai.ZeroMQ
                     else responseContext.Response.OnCompleted(() => poller.Run(SendResponse));
                 };
                 poller.RunAsync();
-                return new CompositeDisposable
+                return Disposable.Create(() => Task.Run(() =>
                 {
-                    Disposable.Create(() => Task.Run(() =>
-                    {
-                        poller.Dispose();
-                        router.Dispose();
-                    }))
-                };
+                    poller.Dispose();
+                    router.Dispose();
+                }));
             });
         }
 

--- a/src/Bonsai.ZeroMQ/Subscriber.cs
+++ b/src/Bonsai.ZeroMQ/Subscriber.cs
@@ -46,8 +46,12 @@ namespace Bonsai.ZeroMQ
                 var poller = new NetMQPoller { subscriber };
                 subscriber.ReceiveReady += (sender, e) =>
                 {
-                    var message = e.Socket.ReceiveMultipartMessage();
-                    observer.OnNext(message);
+                    NetMQMessage message = default;
+                    while (e.Socket.TryReceiveMultipartMessage(ref message))
+                    {
+                        observer.OnNext(message);
+                        message = default;
+                    }
                 };
                 subscriber.Subscribe(topic);
                 poller.RunAsync();


### PR DESCRIPTION
This PR ensures that the event infrastructure of the `NetMQPoller` class is used for all receive sockets. Rather than using blocking calls to receive methods, a subscription is made to the `ReceiveReady` event. This also ensures that cancellation can always break out of the listening loop.

Fixes #10 