### PR TITLE
Remove internal counter from dealer socket

### DIFF
--- a/src/Bonsai.ZeroMQ/Bonsai.ZeroMQ.csproj
+++ b/src/Bonsai.ZeroMQ/Bonsai.ZeroMQ.csproj
@@ -17,7 +17,7 @@
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.ZeroMQ/Dealer.cs
+++ b/src/Bonsai.ZeroMQ/Dealer.cs
@@ -90,15 +90,9 @@ namespace Bonsai.ZeroMQ
                     }
                 };
                 var sourceObserver = Observer.Create<TSource>(
-                    request =>
-                    {
-                        sendRequest(dealer.SendMoreFrameEmpty(), request);
-                    },
+                    request => sendRequest(dealer.SendMoreFrameEmpty(), request),
                     observer.OnError,
-                    () =>
-                    {
-                        observer.OnCompleted();
-                    });
+                    () => { });
                 poller.RunAsync();
                 return new CompositeDisposable
                 {


### PR DESCRIPTION
This PR is in relation to issue #15 and addresses it by removing the internal counter from Dealers entirely. 

A Dealer socket is expected to be used as a fully asynchronous channel between client and server, and either of them can send arbitrary message streams to each other, without any constraints on pairing requests to responses (in a way there is no concept of "request" or "response" in a dealer, only messages).

The client-server article in the updated docs provides an example of such a flexible use which depends on this change.